### PR TITLE
Create model eval class, create test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ models
 .DS_Store
 *.csv
 /data
+git_helper.txt

--- a/dlt_project_env.yml
+++ b/dlt_project_env.yml
@@ -12,6 +12,7 @@ dependencies:
   - matplotlib
   - altair
   - plotnine
+  - scikit-learn
   - pip:
     - datasets
     - transformers

--- a/src/eval.py
+++ b/src/eval.py
@@ -1,0 +1,213 @@
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+from datasets import load_dataset
+import torch
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+from sklearn.metrics import accuracy_score, precision_recall_fscore_support
+from pprint import pprint
+
+from utils import *
+
+def prepare_data_loader(
+    name='imdb',
+    split='test',
+    model_dict=MODEL_DICT,
+    sample_size=None,
+    batch_size=16
+):
+  """ Loads and processes a dataset from the HuggingFace library"""
+  dataset = load_dataset(name, split=split)
+  if sample_size:
+    data_size = len(dataset)
+    sample_indices = np.random.choice(data_size, size=sample_size, replace=False)
+    dataset = dataset.select(sample_indices)
+
+  tokenizer = AutoTokenizer.from_pretrained(
+      model_dict['distilbert']['pretrained_model'])
+  dataset = dataset.map(
+    lambda batch: tokenizer(
+      batch['text'],
+      padding='max_length',
+      truncation=True,
+      return_tensors='pt'
+    ),
+    batched=True
+  )
+  dataset.set_format('torch', columns=['input_ids', 'attention_mask', 'label'])
+
+  data_loader = DataLoader(dataset, batch_size=batch_size)
+  return data_loader
+
+
+class SentimentAnalysisPipeline:
+  def __init__(self, model_alias='distilbert', model_dict=MODEL_DICT, device=None):
+    """Initializes the pipeline
+
+    Args:
+      model_alias (str, optional): Alias of the model to use. Defaults to 'distilbert'.
+      model_dict (dict, optional):
+        Dictionary containing the model aliases and pretrained models.
+        Should be defined in the utils module. Defaults to MODEL_DICT.
+      device ([type], optional): Device to use for training. Defaults to None.
+    """
+    self.model_name = model_dict[model_alias]['pretrained_model']
+    self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+    self.model = AutoModelForSequenceClassification.from_pretrained(
+        self.model_name)
+    self.device = device or torch.device(
+        "cuda" if torch.cuda.is_available() else "cpu")
+    self.model.to(self.device)
+
+  def evaluate_model(
+      self,
+      data_loader,
+      num_bits_to_flip=None,
+      swap_index_tensor=None
+  ):
+    """Evaluates the model on a dataset
+
+    Args:
+      data_loader ([torch.utils.data.DataLoader]): Dataloader to evaluate on.
+      num_bits_to_flip (int, optional): Number of bits to flip in the
+        attention mask. Defaults to None.
+      swap_index_tensor (torch.Tensor, optional): 2D tensor containing
+        indices to swap to '0'. Defaults to None.
+
+    Returns:
+      dict: Evaluation metrics (accuracy, precision, recall, f1)
+    """
+    self.model.eval()
+    all_predictions = []
+    all_true_labels = []
+
+    with torch.no_grad():
+      for i, batch in enumerate(tqdm(data_loader, desc="Evaluation")):
+        labels = batch.pop('label').cpu().numpy()
+        # Flip the attention mask bits for the current batch, if specified.
+        if num_bits_to_flip is not None or swap_index_tensor is not None:
+          if swap_index_tensor is not None:
+            # Calculate the start and end indices for the current batch.
+            start_idx = i * data_loader.batch_size
+            end_idx = min(start_idx + data_loader.batch_size,
+                          len(swap_index_tensor))
+            current_swap_indices = swap_index_tensor[start_idx:end_idx]
+          else:
+            current_swap_indices = None
+          batch['attention_mask'] = self._disable_attention_mask_bits(
+            batch['attention_mask'],
+            num_bits=num_bits_to_flip,
+            swap_index_tensor=current_swap_indices
+          )
+        # Continue evaluation as normal.
+        batch = self._to_device(batch)
+        outputs = self.model(**batch)
+        predictions = torch.argmax(outputs.logits, dim=-1).cpu().numpy()
+        all_predictions.extend(predictions)
+        all_true_labels.extend(labels)
+
+    accuracy = accuracy_score(all_true_labels, all_predictions)
+    precision, recall, f1, _ = precision_recall_fscore_support(all_true_labels, all_predictions, average='binary')
+
+    return {
+        'accuracy': accuracy,
+        'precision': precision,
+        'recall': recall,
+        'f1': f1
+    }
+
+  def _encode_batch(self, batch):
+    """Encodes a batch of data using the model tokenizer
+
+    Args:
+      batch (dict): Batch of data to encode
+
+    Returns:
+      dict: Encoded batch
+    """
+    return self.tokenizer(
+      batch['text'],
+      padding='max_length',
+      truncation=True,
+      return_tensors='pt'
+    )
+
+
+  def _to_device(self, batch):
+    """Moves a batch to the device"""
+    return {k: v.to(self.device) for k, v in batch.items()}
+
+  def _random_swap(self, attention_row, num_bits):
+    """Helper function to swap random bits in an attention mask row to 0."""
+    num_cols = attention_row.size(0)
+    rand_indices = torch.randperm(num_cols)[:num_bits]
+    attention_row[rand_indices] = 0
+
+  def _swap_with_indices(self, attention_row, swap_indices, num_bits):
+    """Helper function to swap specified bits in an attention mask row to 0."""
+    # Only use the first num_bits indices
+    valid_indices = swap_indices[:num_bits]
+    # Filter out any indices that are out of bounds
+    valid_indices = valid_indices[valid_indices < attention_row.size(0)]
+    attention_row[valid_indices] = 0
+
+  def _check_swap_index_tensor(self, swap_index_tensor, attention_tensor):
+    """Check if swap_index_tensor has the same num of rows as attention_tensor."""
+    if swap_index_tensor.size(0) != attention_tensor.size(0):
+      raise ValueError(f"swap_index_tensor must have the same number of rows "
+        f"(current: {swap_index_tensor.size(0)}) as attention_tensor "
+        f"(input rows: {attention_tensor.size(0)})")
+
+  def _disable_attention_mask_bits(
+      self,
+      attention_tensor,
+      num_bits=10,
+      swap_index_tensor=None
+  ):
+    """Set specified bits in the attention mask to '0', or random bits
+      if no indices are specified.
+
+    Args:
+      attention_tensor (torch.Tensor): 2D attention mask where each row is a mask.
+      num_bits (int): Number of bits to set to '0' for each mask.
+      swap_index_tensor (torch.Tensor): Optional 2D tensor with the same number of
+        rows as attention_tensor, containing indices to swap to '0'.
+
+    Returns:
+      torch.Tensor: Modified 2D attention mask.
+
+    Raises:
+      ValueError: If swap_index_tensor has a different number of rows
+        than attention_tensor.
+    """
+    # Clone the tensor to avoid modifying it in place
+    attention_tensor_copy = attention_tensor.clone()
+
+    if swap_index_tensor is not None:
+      self._check_swap_index_tensor(swap_index_tensor, attention_tensor_copy)
+      for row in range(attention_tensor_copy.size(0)):
+        self._swap_with_indices(
+            attention_tensor_copy[row], swap_index_tensor[row], num_bits)
+    else:
+      for row in range(attention_tensor_copy.size(0)):
+        self._random_swap(attention_tensor_copy[row], num_bits)
+
+    return attention_tensor_copy
+
+
+if __name__ == '__main__':
+  # Usage
+  # Replace with your model name if different
+  model_name = 'distilbert'
+  DATA_SIZE = 50
+
+  pipeline = SentimentAnalysisPipeline(model_alias='distilbert')
+  test_loader = prepare_data_loader(sample_size=DATA_SIZE, batch_size=16)
+
+  # Mask 50 bits from a tensor of indices.
+  # Create a tensor of indices to swap to '0' of size DATA_SIZE x 50:
+  # DATA_SIZE: number of samples in the test set
+  # Only flip top 10 bits in each row.
+  swap_index_tensor = torch.randint(0, 100, size=(DATA_SIZE, 50))
+  test_scores = pipeline.evaluate_model(
+      test_loader, num_bits_to_flip=10, swap_index_tensor=swap_index_tensor)
+  print(test_scores)

--- a/src/eval_test.py
+++ b/src/eval_test.py
@@ -1,0 +1,289 @@
+import unittest
+import torch
+from eval import SentimentAnalysisPipeline
+from eval import prepare_data_loader
+from utils import *
+
+# Core tests of the SentimentAnalysisPipeline class using distilbert.
+class TestSentimentAnalysisPipeline_distilbert(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    # Load a very small sample of the input dataset once for all tests
+    cls.data_loader = prepare_data_loader(sample_size=10, batch_size=8)
+
+    # Initialize the SentimentAnalysisPipeline instance
+    cls.pipeline = SentimentAnalysisPipeline(model_alias='distilbert')
+
+  def test_evaluation_no_params(self):
+    # Test the evaluation with default parameters
+    metrics = self.pipeline.evaluate_model(self.data_loader)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_random_indices(self):
+    # Test the evaluation with random index replacement
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, num_bits_to_flip=5)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, swap_index_tensor=swap_index_tensor)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices_with_num_bits(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader,
+        num_bits_to_flip=10,
+        swap_index_tensor=swap_index_tensor
+    )
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_encode_batch(self):
+    # Test the _encode_batch method
+    batch = {'text': ["This is a test", "Another test"]}
+    encoded_batch = self.pipeline._encode_batch(batch)
+    self.assertTrue(
+        'input_ids' in encoded_batch and 'attention_mask' in encoded_batch)
+
+  def test_to_device(self):
+    # Test the _to_device method
+    batch = {'input_ids': torch.tensor(
+        [[1, 2], [3, 4]]), 'attention_mask': torch.tensor([[1, 1], [1, 0]])}
+    batch_to_device = self.pipeline._to_device(batch)
+    self.assertTrue(
+        all(tensor.device == self.pipeline.device for tensor in batch_to_device.values()))
+
+# Evaluation-only tests of BERT model.
+class TestSentimentAnalysisPipeline_bert(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    # Load a very small sample of the input dataset once for all tests
+    cls.data_loader = prepare_data_loader(sample_size=10, batch_size=8)
+
+    # Initialize the SentimentAnalysisPipeline instance
+    cls.pipeline = SentimentAnalysisPipeline(model_alias='bert')
+
+  def test_evaluation_no_params(self):
+    # Test the evaluation with default parameters
+    metrics = self.pipeline.evaluate_model(self.data_loader)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_random_indices(self):
+    # Test the evaluation with random index replacement
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, num_bits_to_flip=5)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, swap_index_tensor=swap_index_tensor)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices_with_num_bits(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader,
+        num_bits_to_flip=10,
+        swap_index_tensor=swap_index_tensor
+    )
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+# Evaluation-only tests of BART model.
+class TestSentimentAnalysisPipeline_bart(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    # Load a very small sample of the input dataset once for all tests
+    cls.data_loader = prepare_data_loader(sample_size=10, batch_size=8)
+
+    # Initialize the SentimentAnalysisPipeline instance
+    cls.pipeline = SentimentAnalysisPipeline(model_alias='bart')
+
+  def test_evaluation_no_params(self):
+    # Test the evaluation with default parameters
+    metrics = self.pipeline.evaluate_model(self.data_loader)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_random_indices(self):
+    # Test the evaluation with random index replacement
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, num_bits_to_flip=5)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, swap_index_tensor=swap_index_tensor)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices_with_num_bits(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader,
+        num_bits_to_flip=10,
+        swap_index_tensor=swap_index_tensor
+    )
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+# Evaluation-only tests of BART model.
+
+
+class TestSentimentAnalysisPipeline_roberta_sid(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    # Load a very small sample of the input dataset once for all tests
+    cls.data_loader = prepare_data_loader(sample_size=10, batch_size=8)
+
+    # Initialize the SentimentAnalysisPipeline instance
+    cls.pipeline = SentimentAnalysisPipeline(model_alias='roberta_sid')
+
+  def test_evaluation_no_params(self):
+    # Test the evaluation with default parameters
+    metrics = self.pipeline.evaluate_model(self.data_loader)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_random_indices(self):
+    # Test the evaluation with random index replacement
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, num_bits_to_flip=5)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, swap_index_tensor=swap_index_tensor)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices_with_num_bits(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader,
+        num_bits_to_flip=10,
+        swap_index_tensor=swap_index_tensor
+    )
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+
+class TestSentimentAnalysisPipeline_bert_souraj(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    # Load a very small sample of the input dataset once for all tests
+    cls.data_loader = prepare_data_loader(sample_size=10, batch_size=8)
+
+    # Initialize the SentimentAnalysisPipeline instance
+    cls.pipeline = SentimentAnalysisPipeline(model_alias='bert_souraj')
+
+  def test_evaluation_no_params(self):
+    # Test the evaluation with default parameters
+    metrics = self.pipeline.evaluate_model(self.data_loader)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_random_indices(self):
+    # Test the evaluation with random index replacement
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, num_bits_to_flip=5)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, swap_index_tensor=swap_index_tensor)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices_with_num_bits(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader,
+        num_bits_to_flip=10,
+        swap_index_tensor=swap_index_tensor
+    )
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+
+class TestSentimentAnalysisPipeline_bart_souraj(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    # Load a very small sample of the input dataset once for all tests
+    cls.data_loader = prepare_data_loader(sample_size=10, batch_size=8)
+
+    # Initialize the SentimentAnalysisPipeline instance
+    cls.pipeline = SentimentAnalysisPipeline(model_alias='bart_souraj')
+
+  def test_evaluation_no_params(self):
+    # Test the evaluation with default parameters
+    metrics = self.pipeline.evaluate_model(self.data_loader)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_random_indices(self):
+    # Test the evaluation with random index replacement
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, num_bits_to_flip=5)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader, swap_index_tensor=swap_index_tensor)
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+  def test_evaluation_specific_indices_with_num_bits(self):
+    # Test the evaluation with a specific index matrix
+    # Assuming the attention mask length is 512
+    swap_index_tensor = torch.randint(0, 512, (10, 5))
+    metrics = self.pipeline.evaluate_model(
+        self.data_loader,
+        num_bits_to_flip=10,
+        swap_index_tensor=swap_index_tensor
+    )
+    self.assertIsInstance(metrics, dict)
+    self.assertTrue('accuracy' in metrics)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/src/utils_test.py
+++ b/src/utils_test.py
@@ -1,1 +1,55 @@
-#(TODO): Setup simple test cases for the utils module.
+import unittest
+from utils import *
+from datasets import load_dataset
+
+imdb = get_data("imdb", 0.05)
+
+
+class UtilsTest(unittest.TestCase):
+  def test_CLS_attention_for_single_model(self):
+    """Test CLS attention per token function for a single model."""
+    model_alias = 'distilbert'
+    data_size = 4
+    sample_text = imdb['test']['text'][:data_size]
+    sample_label = imdb['test']['label'][:data_size]
+
+    tokenized_input, output, cls_att_mean, cls_att_grad_mean = get_CLS_attention_per_token(
+      model_alias,
+      sample_text,
+      sample_label,
+      return_cls_only=False
+    )
+
+    self.assertEqual(cls_att_mean.shape[0], data_size)
+    self.assertEqual(cls_att_grad_mean.shape[0], data_size)
+
+    print_index = 0
+    print_attention_weights(
+      tokenized_input[print_index].tokens, cls_att_mean[print_index])
+
+    print_model_output_stats(
+      model_alias, sample_label, tokenized_input, output, cls_att_mean, cls_att_grad_mean)
+
+  def test_CLS_attention_for_multiple_models(self):
+    """Test CLS attention per token function for multiple models."""
+    data_size = 4
+    sample_text = imdb['test']['text'][:data_size]
+    sample_label = imdb['test']['label'][:data_size]
+
+    for model_alias in MODEL_DICT.keys():
+      tokenized_input, output, cls_att_mean, cls_att_grad_mean = get_CLS_attention_per_token(
+        model_alias,
+        sample_text,
+        sample_label,
+        return_cls_only=False
+      )
+
+      self.assertEqual(cls_att_mean.shape[0], data_size)
+      self.assertEqual(cls_att_grad_mean.shape[0], data_size)
+
+      print_model_output_stats(
+        model_alias, sample_label, tokenized_input, output, cls_att_mean, cls_att_grad_mean)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
- Creates a standard model evaluation pipeline with several important additions:
  - You can directly modify the input attention_mask to "mask" specific tokens in the input
  - Can either be completely random or according to an index-ranking matrix
- Added test class for eval.py to test the eval loop on all models + for various input combinations:
  - Simple eval on imdb dataset as is
  - Masking random input tokens and running eval
  - Masking specific input tokens from a specified matrix with indices of tokens to drop
- Added test class for utils.py to make sure CLS_attention functions run properly